### PR TITLE
Skip optional variables which are set to None

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,16 @@
-## GraphQL Client
+# GraphQL Client
 
 This is a simple graphQL client which can be used by other TDR projects to communicate with the consignment API and any other future graphQL APIs.
 
 [GraphQLService](src/main/scala/uk/gov/nationalarchives/tdr/GraphQLService.scala) contains a single method to get a client.
 [GraphQLClient](src/main/scala/uk/gov/nationalarchives/tdr/GraphQLClient.scala) contains the logic for the client. It takes generated case classes as arguments which are found in the [generated graphql](https://github.com/nationalarchives/tdr-generated-graphql) project.
 
+## Local development
+
+To publish the library locally, run:
+
+```
+sbt +package +publishLocal
+```
+
+The `+` signs mean that those commands are run for each Scala version specified in this project's build.sbt file.

--- a/src/test/scala/uk/gov/nationalarchives/tdr/GraphQLClientTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/GraphQLClientTest.scala
@@ -3,7 +3,7 @@ package uk.gov.nationalarchives.tdr
 import java.util.concurrent.TimeUnit
 
 import com.github.tomakehurst.wiremock.WireMockServer
-import com.github.tomakehurst.wiremock.client.WireMock.{okJson, post, urlEqualTo, unauthorized}
+import com.github.tomakehurst.wiremock.client.WireMock._
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken
 import io.circe.Printer
 import io.circe.generic.auto._
@@ -11,8 +11,9 @@ import io.circe.syntax._
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import uk.gov.nationalarchives.tdr.GraphQLTestDocument.getSeries.{Data, GetSeries, Variables, document}
+import uk.gov.nationalarchives.tdr.testdata.AddFileTestDocument.addFile.{AddFileInput, AddFileVariables, FileResponseData, addFileDocument}
 import uk.gov.nationalarchives.tdr.GraphQLClient.GraphqlError
+import uk.gov.nationalarchives.tdr.testdata.GetSeriesTestDocument.getSeries.{GetSeries, GetSeriesVariables, SeriesResponseData, getSeriesDocument}
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext}
@@ -27,21 +28,22 @@ class GraphQLClientTest extends AnyFlatSpec with Matchers with BeforeAndAfterEac
   }
 
   override def afterEach(): Unit = {
+    wiremockServer.resetAll()
     wiremockServer.stop()
   }
 
-  case class GraphqlData(data: Option[Data], errors: List[GraphqlError] = Nil)
+  case class GraphqlData(data: Option[SeriesResponseData], errors: List[GraphqlError] = Nil)
 
   "The getResult method " should "return the correct result" in {
-    val data= GraphqlData(Some(Data(List(GetSeries(1L, Option.empty,Option.empty, Some("code"), Option.empty)))))
+    val data= GraphqlData(Some(SeriesResponseData(List(GetSeries(1L, Option.empty,Option.empty, Some("code"), Option.empty)))))
 
     val dataString: String = data.asJson.printWith(Printer(dropNullValues = false, ""))
 
     wiremockServer.stubFor(post(urlEqualTo("/graphql"))
       .willReturn(okJson(dataString)))
 
-    val result = new GraphQLClient[Data, Variables]("http://localhost:9006/graphql").getResult(new BearerAccessToken("token"), document, Option.empty)
-    val resultData: GraphQLClient[Data, Variables]#GraphqlData = Await.result(result, Duration(1, TimeUnit.HOURS))
+    val result = new GraphQLClient[SeriesResponseData, GetSeriesVariables]("http://localhost:9006/graphql").getResult(new BearerAccessToken("token"), getSeriesDocument, Option.empty)
+    val resultData: GraphQLClient[SeriesResponseData, GetSeriesVariables]#GraphqlData = Await.result(result, Duration(1, TimeUnit.HOURS))
     assert(resultData.data.isDefined)
     assert(resultData.data.get.getSeries.nonEmpty)
     resultData.data.get.getSeries.head.seriesid should equal(1L)
@@ -55,8 +57,8 @@ class GraphQLClientTest extends AnyFlatSpec with Matchers with BeforeAndAfterEac
     wiremockServer.stubFor(post(urlEqualTo("/graphql"))
       .willReturn(okJson(dataString)))
 
-    val result = new GraphQLClient[Data, Variables]("http://localhost:9006/graphql").getResult(new BearerAccessToken("token"), document, Option.empty)
-    val resultData: GraphQLClient[Data, Variables]#GraphqlData = Await.result(result, Duration(1, TimeUnit.HOURS))
+    val result = new GraphQLClient[SeriesResponseData, GetSeriesVariables]("http://localhost:9006/graphql").getResult(new BearerAccessToken("token"), getSeriesDocument, Option.empty)
+    val resultData: GraphQLClient[SeriesResponseData, GetSeriesVariables]#GraphqlData = Await.result(result, Duration(1, TimeUnit.HOURS))
     assert(resultData.data.isEmpty)
     assert(resultData.errors.nonEmpty)
     resultData.errors.head.message should equal("error")
@@ -65,8 +67,8 @@ class GraphQLClientTest extends AnyFlatSpec with Matchers with BeforeAndAfterEac
   "The getResult method " should "return an appropriate error if the api returns an error" in {
     wiremockServer.stubFor(post(urlEqualTo("/graphql"))
       .willReturn(unauthorized().withBody("Unauthorised")))
-    val result = new GraphQLClient[Data, Variables]("http://localhost:9006/graphql").getResult(new BearerAccessToken("token"), document, Option.empty)
-    val resultData: GraphQLClient[Data, Variables]#GraphqlData = Await.result(result, Duration(1, TimeUnit.HOURS))
+    val result = new GraphQLClient[SeriesResponseData, GetSeriesVariables]("http://localhost:9006/graphql").getResult(new BearerAccessToken("token"), getSeriesDocument, Option.empty)
+    val resultData: GraphQLClient[SeriesResponseData, GetSeriesVariables]#GraphqlData = Await.result(result, Duration(1, TimeUnit.HOURS))
     assert(resultData.data.isEmpty)
     assert(resultData.errors.nonEmpty)
     resultData.errors.head.message should equal("Unauthorised")
@@ -75,10 +77,37 @@ class GraphQLClientTest extends AnyFlatSpec with Matchers with BeforeAndAfterEac
   "The getResult method " should "return no data if the api response is invalid" in {
     wiremockServer.stubFor(post(urlEqualTo("/graphql"))
       .willReturn(okJson("{\"status\": \"ok\"}")))
-    val result = new GraphQLClient[Data, Variables]("http://localhost:9006/graphql").getResult(new BearerAccessToken("token"), document, Option.empty)
-    val resultData: GraphQLClient[Data, Variables]#GraphqlData = Await.result(result, Duration(1, TimeUnit.HOURS))
+    val result = new GraphQLClient[SeriesResponseData, GetSeriesVariables]("http://localhost:9006/graphql").getResult(new BearerAccessToken("token"), getSeriesDocument, Option.empty)
+    val resultData: GraphQLClient[SeriesResponseData, GetSeriesVariables]#GraphqlData = Await.result(result, Duration(1, TimeUnit.HOURS))
     assert(resultData.data.isEmpty)
     assert(resultData.errors.isEmpty)
   }
 
+  "The client" should "include optional values which are provided in the variables" in {
+    wiremockServer.stubFor(post(urlEqualTo("/graphql"))
+      .willReturn(okJson("some response body")))
+
+    val variables = AddFileVariables(AddFileInput(123, Some("some file name")))
+
+    val result = new GraphQLClient[FileResponseData, AddFileVariables]("http://localhost:9006/graphql")
+      .getResult(new BearerAccessToken("token"), addFileDocument, Some(variables))
+    Await.result(result, Duration(1, TimeUnit.HOURS))
+
+    wiremockServer.verify(postRequestedFor(urlMatching("/graphql"))
+      .withRequestBody(matchingJsonPath("$.variables.addFileInput.name", matching("some file name"))))
+  }
+
+  "The client" should "skip optional values which are set to None" in {
+    wiremockServer.stubFor(post(urlEqualTo("/graphql"))
+      .willReturn(okJson("some response body")))
+
+    val variables = AddFileVariables(AddFileInput(123, None))
+
+    val result = new GraphQLClient[FileResponseData, AddFileVariables]("http://localhost:9006/graphql")
+      .getResult(new BearerAccessToken("token"), addFileDocument, Some(variables))
+    Await.result(result, Duration(1, TimeUnit.HOURS))
+
+    wiremockServer.verify(postRequestedFor(urlMatching("/graphql"))
+      .withRequestBody(notMatching(".*\"name\":null.*")))
+  }
 }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/testdata/AddFileTestDocument.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/testdata/AddFileTestDocument.scala
@@ -1,0 +1,29 @@
+package uk.gov.nationalarchives.tdr.testdata
+
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.{Decoder, Encoder}
+import sangria.macros._
+
+object AddFileTestDocument {
+  object addFile {
+    val addFileDocument: sangria.ast.Document = graphql"""mutation addfile($$addFileInput: AddFileInput!) {
+  addFile(addFileInput: $$addFileInput) {
+    fileId
+  }
+}"""
+    case class AddFileVariables(addFileInput: AddFileInput)
+    object AddFileVariables { implicit val jsonEncoder: Encoder[AddFileVariables] = deriveEncoder[AddFileVariables] }
+    case class AddFileInput(consignmentId: Long, name: Option[String])
+    case object AddFileInput {
+      implicit val jsonDecoder: Decoder[AddFileInput] = deriveDecoder[AddFileInput]
+      implicit val jsonEncoder: Encoder[AddFileInput] = deriveEncoder[AddFileInput]
+    }
+    case class AddFile(fileId: String)
+    object AddFile {
+      implicit val jsonDecoder: Decoder[AddFile] = deriveDecoder[AddFile]
+      implicit val jsonEncoder: Encoder[AddFile] = deriveEncoder[AddFile]
+    }
+    case class FileResponseData(addFile: AddFile)
+    object FileResponseData { implicit val jsonDecoder: Decoder[FileResponseData] = deriveDecoder[FileResponseData] }
+  }
+}

--- a/src/test/scala/uk/gov/nationalarchives/tdr/testdata/GetSeriesTestDocument.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/testdata/GetSeriesTestDocument.scala
@@ -1,12 +1,12 @@
-package uk.gov.nationalarchives.tdr
+package uk.gov.nationalarchives.tdr.testdata
 
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.{Decoder, Encoder}
 import sangria.macros._
 
-object GraphQLTestDocument {
+object GetSeriesTestDocument {
   object getSeries {
-    val document: sangria.ast.Document = graphql"""query getSeries($$body: String) {
+    val getSeriesDocument: sangria.ast.Document = graphql"""query getSeries($$body: String) {
   getSeries(body: $$body) {
     seriesid
     bodyid
@@ -15,10 +15,10 @@ object GraphQLTestDocument {
     description
   }
 }"""
-    case class Variables(body: Option[String])
-    object Variables { implicit val jsonEncoder: Encoder[Variables] = deriveEncoder[Variables] }
-    case class Data(getSeries: List[GetSeries])
-    object Data { implicit val jsonDecoder: Decoder[Data] = deriveDecoder[Data] }
+    case class GetSeriesVariables(body: Option[String])
+    object GetSeriesVariables { implicit val jsonEncoder: Encoder[GetSeriesVariables] = deriveEncoder[GetSeriesVariables] }
+    case class SeriesResponseData(getSeries: List[GetSeries])
+    object SeriesResponseData { implicit val jsonDecoder: Decoder[SeriesResponseData] = deriveDecoder[SeriesResponseData] }
     case class GetSeries(seriesid: Long, bodyid: Option[Long], name: Option[String], code: Option[String], description: Option[String])
     object GetSeries {
       implicit val jsonDecoder: Decoder[GetSeries] = deriveDecoder[GetSeries]


### PR DESCRIPTION
Before, optional variables with a value of `None` were encoded as JSON `null` values. This made it impossible to remove optional variables from the API, because the client would still try to set a (null) value for that variable, which causes a Sangria error.

Now, optional variables are only encoded if they have a value. None values are removed from the JSON altogether, making it possible to deprecated variables.