### PR TITLE
Bump snapshot version number to 0.0.5-SNAPSHOT

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.4-SNAPSHOT"
+version in ThisBuild := "0.0.5-SNAPSHOT"


### PR DESCRIPTION
It looks like a previous Jenkins build published 0.0.4 to Sonatype Nexus but didn't bump the snapshot version. This means that later releases are failing because we can't update an existing version.

Bumping the version number manually should fix the release errors.