### PR TITLE
Remove getAccountNumberFromStage function as not used

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,13 +28,3 @@ pipeline {
         }
     }
 }
-
-def getAccountNumberFromStage() {
-    def stageToAccountMap = [
-            "intg": env.INTG_ACCOUNT,
-            "staging": env.STAGING_ACCOUNT,
-            "prod": env.PROD_ACCOUNT
-    ]
-
-    return stageToAccountMap.get(params.STAGE)
-}


### PR DESCRIPTION
If needed, shared functions can be accessed from Jenkinslib 