### PR TITLE
Tdr 407 take implicit backend

### DIFF
--- a/src/test/scala/uk/gov/nationalarchives/tdr/ErrorHandlingTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/ErrorHandlingTest.scala
@@ -4,15 +4,21 @@ import com.github.tomakehurst.wiremock.client.WireMock._
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken
 import org.scalatest.concurrent.ScalaFutures._
 import org.scalatest.matchers.should.Matchers
+import sttp.client.SttpBackend
+import sttp.client.asynchttpclient.WebSocketHandler
+import sttp.client.asynchttpclient.future.AsyncHttpClientFutureBackend
 import sttp.model.StatusCode
 import uk.gov.nationalarchives.tdr.GraphQLClient.Location
 import uk.gov.nationalarchives.tdr.error.{HttpException, NotAuthorisedError, ResponseDecodingException, UnknownGraphQlError}
 import uk.gov.nationalarchives.tdr.testdata.AddFileTestDocument.addFile.addFileDocument
 import uk.gov.nationalarchives.tdr.testdata.GetSeriesTestDocument.getSeries.{GetSeriesVariables, SeriesResponseData}
 
+import scala.concurrent.Future
 import scala.io.Source.fromResource
 
 class ErrorHandlingTest extends WireMockTest with Matchers {
+
+  implicit val backend: SttpBackend[Future, Nothing, WebSocketHandler] = AsyncHttpClientFutureBackend()
 
   def getSeriesClient = new GraphQLClient[SeriesResponseData, GetSeriesVariables](graphQlUrl)
 

--- a/src/test/scala/uk/gov/nationalarchives/tdr/GraphQLClientTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/GraphQLClientTest.scala
@@ -8,18 +8,22 @@ import io.circe.Printer
 import io.circe.generic.auto._
 import io.circe.syntax._
 import org.scalatest.matchers.should.Matchers
+import sttp.client.SttpBackend
+import sttp.client.asynchttpclient.WebSocketHandler
+import sttp.client.asynchttpclient.future.AsyncHttpClientFutureBackend
 import uk.gov.nationalarchives.tdr.GraphQLClient.Error
 import uk.gov.nationalarchives.tdr.testdata.AddFileTestDocument.addFile.{AddFileInput, AddFileVariables, FileResponseData, addFileDocument}
 import uk.gov.nationalarchives.tdr.testdata.GetSeriesTestDocument.getSeries.{GetSeries, GetSeriesVariables, SeriesResponseData, getSeriesDocument}
 
 import scala.concurrent.duration.Duration
-import scala.concurrent.{Await, Awaitable}
+import scala.concurrent.{Await, Awaitable, Future}
 
 class GraphQLClientTest extends WireMockTest with Matchers {
   def getSeriesClient = new GraphQLClient[SeriesResponseData, GetSeriesVariables](graphQlUrl)
   def addFileClient = new GraphQLClient[FileResponseData, AddFileVariables](graphQlUrl)
 
   def await[T](result: Awaitable[T]): T = Await.result(result, Duration(5, TimeUnit.SECONDS))
+  implicit val backend: SttpBackend[Future, Nothing, WebSocketHandler] = AsyncHttpClientFutureBackend()
 
   case class GraphqlData(data: Option[SeriesResponseData], errors: List[Error] = Nil)
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.16"
+version in ThisBuild := "0.0.17-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.16-SNAPSHOT"
+version in ThisBuild := "0.0.16"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.14-SNAPSHOT"
+version in ThisBuild := "0.0.16-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.17-SNAPSHOT"
+version in ThisBuild := "0.0.14-SNAPSHOT"


### PR DESCRIPTION
You now need to pass in an sttp backend to the getResult method. Because
the first type to the SttpBackend type is a higher kinded type, you
can't directly check the type and this is the way that works.

We could have had a separate method which uses the sync backend but this
feels more scala-y.