### PR TITLE
Upgrade sttp

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   lazy val circeVersion = "0.13.0"
-  lazy val sttpVersion = "2.2.4"
+  lazy val sttpVersion = "3.3.15"
 
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.0-M2"
   lazy val wiremock = "com.github.tomakehurst" % "wiremock-jre8" % "2.26.0"
@@ -10,9 +10,9 @@ object Dependencies {
   lazy val circeParser = "io.circe" %% "circe-parser" % circeVersion
   lazy val circeGeneric = "io.circe" %% "circe-generic" % circeVersion
   lazy val circeGenericExtras = "io.circe" %% "circe-generic-extras" % circeVersion
-  lazy val sttp = "com.softwaremill.sttp.client" %% "core" % sttpVersion
-  lazy val sttpCirce = "com.softwaremill.sttp.client" %% "circe" % sttpVersion
-  lazy val sttpAsyncClient = "com.softwaremill.sttp.client" %% "async-http-client-backend-future" % sttpVersion
+  lazy val sttp = "com.softwaremill.sttp.client3" %% "core" % sttpVersion
+  lazy val sttpCirce = "com.softwaremill.sttp.client3" %% "circe" % sttpVersion
+  lazy val sttpAsyncClient = "com.softwaremill.sttp.client3" %% "async-http-client-backend-future" % sttpVersion
   lazy val oauth2 = "com.nimbusds" % "oauth2-oidc-sdk" % "6.23"
   lazy val sangria = "org.sangria-graphql" %% "sangria" % "2.0.0-M3"
 }

--- a/src/main/scala/uk/gov/nationalarchives/tdr/error/HttpException.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/error/HttpException.scala
@@ -2,7 +2,7 @@ package uk.gov.nationalarchives.tdr.error
 
 import java.io.IOException
 
-import sttp.client.Response
+import sttp.client3.Response
 import sttp.model.StatusCode
 
 class HttpException(val response: Response[Either[String, String]])


### PR DESCRIPTION
The new backend check performance tests are using a newer version of
cats-effect which in turn needs a newer version of sttp.

It seems like a good time to upgrade this. There may be conflicts if we
try to use this somewhere that already has sttp elsewhere but we should
be able to fix those without too many issues.
