### PR TITLE
dependency updates

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   lazy val circeVersion = "0.14.1"
-  lazy val sttpVersion = "3.3.18"
+  lazy val sttpVersion = "3.5.1"
 
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.12-RC2"
   lazy val wiremock = "com.github.tomakehurst" % "wiremock-jre8" % "2.26.3"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,5 +14,5 @@ object Dependencies {
   lazy val sttpCirce = "com.softwaremill.sttp.client3" %% "circe" % sttpVersion
   lazy val sttpAsyncClient = "com.softwaremill.sttp.client3" %% "async-http-client-backend-future" % sttpVersion
   lazy val oauth2 = "com.nimbusds" % "oauth2-oidc-sdk" % "9.32"
-  lazy val sangria = "org.sangria-graphql" %% "sangria" % "2.0.1"
+  lazy val sangria = "org.sangria-graphql" %% "sangria" % "2.1.6"
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   lazy val sttpVersion = "3.5.1"
 
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.12-RC2"
-  lazy val wiremock = "com.github.tomakehurst" % "wiremock-jre8" % "2.26.3"
+  lazy val wiremock = "com.github.tomakehurst" % "wiremock-jre8" % "2.32.0"
   lazy val circeCore = "io.circe" %% "circe-core" % circeVersion
   lazy val circeParser = "io.circe" %% "circe-parser" % circeVersion
   lazy val circeGeneric = "io.circe" %% "circe-generic" % circeVersion

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.github.sbt" % "sbt-release" % "1.0.15")
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 resolvers += Resolver.jcenterRepo
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.12")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")


### PR DESCRIPTION
- Update sbt-release to 1.1.0
- Update wiremock-jre8 to 2.32.0
- Update client3:async-http-client-backend-future, ... to 3.5.1
- Update sangria to 2.1.6
