### PR TITLE
Remove async-http-client-backend-future.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,7 +61,6 @@ lazy val root = (project in file("."))
       circeGenericExtras,
       sttp,
       sttpCirce,
-      sttpAsyncClient,
       oauth2,
       sangria
     )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,6 @@ object Dependencies {
   lazy val circeGenericExtras = "io.circe" %% "circe-generic-extras" % circeVersion
   lazy val sttp = "com.softwaremill.sttp.client3" %% "core" % sttpVersion
   lazy val sttpCirce = "com.softwaremill.sttp.client3" %% "circe" % sttpVersion
-  lazy val sttpAsyncClient = "com.softwaremill.sttp.client3" %% "async-http-client-backend-future" % sttpVersion
   lazy val oauth2 = "com.nimbusds" % "oauth2-oidc-sdk" % "9.35"
   lazy val sangria = "org.sangria-graphql" %% "sangria" % "3.0.0"
 }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/ErrorHandlingTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/ErrorHandlingTest.scala
@@ -4,8 +4,7 @@ import com.github.tomakehurst.wiremock.client.WireMock._
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken
 import org.scalatest.concurrent.ScalaFutures._
 import org.scalatest.matchers.should.Matchers
-import sttp.client3.SttpBackend
-import sttp.client3.asynchttpclient.future.AsyncHttpClientFutureBackend
+import sttp.client3.{HttpClientFutureBackend, SttpBackend}
 import sttp.model.StatusCode
 import uk.gov.nationalarchives.tdr.GraphQLClient.Location
 import uk.gov.nationalarchives.tdr.error.{HttpException, NotAuthorisedError, ResponseDecodingException, UnknownGraphQlError}
@@ -17,7 +16,7 @@ import scala.io.Source.fromResource
 
 class ErrorHandlingTest extends WireMockTest with Matchers {
 
-  implicit val backend: SttpBackend[Future, Any] = AsyncHttpClientFutureBackend()
+  implicit val backend: SttpBackend[Future, Any] = HttpClientFutureBackend()
 
   def getSeriesClient = new GraphQLClient[SeriesResponseData, GetSeriesVariables](graphQlUrl)
 

--- a/src/test/scala/uk/gov/nationalarchives/tdr/GraphQLClientTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/GraphQLClientTest.scala
@@ -1,15 +1,13 @@
 package uk.gov.nationalarchives.tdr
 
 import java.util.concurrent.TimeUnit
-
 import com.github.tomakehurst.wiremock.client.WireMock._
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken
 import io.circe.Printer
 import io.circe.generic.auto._
 import io.circe.syntax._
 import org.scalatest.matchers.should.Matchers
-import sttp.client3.SttpBackend
-import sttp.client3.asynchttpclient.future.AsyncHttpClientFutureBackend
+import sttp.client3.{HttpClientFutureBackend, SttpBackend}
 import uk.gov.nationalarchives.tdr.GraphQLClient.Error
 import uk.gov.nationalarchives.tdr.testdata.AddFileTestDocument.addFile.{AddFileInput, AddFileVariables, FileResponseData, addFileDocument}
 import uk.gov.nationalarchives.tdr.testdata.GetSeriesTestDocument.getSeries.{GetSeries, GetSeriesVariables, SeriesResponseData, getSeriesDocument}
@@ -22,7 +20,7 @@ class GraphQLClientTest extends WireMockTest with Matchers {
   def addFileClient = new GraphQLClient[FileResponseData, AddFileVariables](graphQlUrl)
 
   def await[T](result: Awaitable[T]): T = Await.result(result, Duration(5, TimeUnit.SECONDS))
-  implicit val backend: SttpBackend[Future, Any] = AsyncHttpClientFutureBackend()
+  implicit val backend: SttpBackend[Future, Any] = HttpClientFutureBackend()
 
   case class GraphqlData(data: Option[SeriesResponseData], errors: List[Error] = Nil)
 


### PR DESCRIPTION
There is a snyk alert for a CVE on one of the dependencies of this
library. We don't actually need it, it's only used in two places in the
tests and we can use the normal future backend from the core project
there so I've taken it out.
