### PR TITLE
TDRD-716 - Add readTimout as parameter in the gerResult

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/GraphQLClient.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/GraphQLClient.scala
@@ -14,7 +14,7 @@ import uk.gov.nationalarchives.tdr.GraphQLClient.Error
 import uk.gov.nationalarchives.tdr.error.{HttpException, ResponseDecodingException, _}
 
 import scala.collection.immutable
-import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration.{Duration, DurationInt}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.reflect.{ClassTag, classTag}
 

--- a/src/main/scala/uk/gov/nationalarchives/tdr/GraphQLClient.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/GraphQLClient.scala
@@ -24,7 +24,11 @@ class GraphQLClient[Data, Variables](url: String)(implicit val ec: ExecutionCont
 
   case class GraphqlData(data: Option[Data], errors: List[Error] = Nil)
 
-  def getResult[T[_]](token: BearerAccessToken, document: Document, variables: Option[Variables] = Option.empty, readTimeout: Duration = 60.seconds)(implicit backend: SttpBackend[T, Any], tag: ClassTag[T[_]]): Future[GraphQlResponse[Data]] = {
+  def getResult[T[_]](token: BearerAccessToken, document: Document, variables: Option[Variables] = Option.empty)(implicit backend: SttpBackend[T, Any], tag: ClassTag[T[_]]): Future[GraphQlResponse[Data]] = {
+    getResult(token, document, variables, 60.seconds)
+  }
+
+  def getResult[T[_]](token: BearerAccessToken, document: Document, variables: Option[Variables], readTimeout: Duration)(implicit backend: SttpBackend[T, Any], tag: ClassTag[T[_]]): Future[GraphQlResponse[Data]] = {
     val queryJson: Json = Json.fromString(QueryRenderer.render(document, QueryRenderer.Compact))
     val variablesJson: Option[Json] = variables.map(_.asJson)
     val fields: immutable.Seq[(String, Json)] = List("query" -> queryJson) ++ variablesJson.map("variables" -> _)

--- a/src/test/scala/uk/gov/nationalarchives/tdr/GraphQLClientTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/GraphQLClientTest.scala
@@ -12,7 +12,7 @@ import uk.gov.nationalarchives.tdr.GraphQLClient.Error
 import uk.gov.nationalarchives.tdr.testdata.AddFileTestDocument.addFile.{AddFileInput, AddFileVariables, FileResponseData, addFileDocument}
 import uk.gov.nationalarchives.tdr.testdata.GetSeriesTestDocument.getSeries.{GetSeries, GetSeriesVariables, SeriesResponseData, getSeriesDocument}
 
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration.{Duration, DurationInt}
 import scala.concurrent.{Await, Awaitable, Future}
 
 class GraphQLClientTest extends WireMockTest with Matchers {
@@ -25,14 +25,14 @@ class GraphQLClientTest extends WireMockTest with Matchers {
   case class GraphqlData(data: Option[SeriesResponseData], errors: List[Error] = Nil)
 
   "The getResult method " should "return the correct result" in {
-    val data= GraphqlData(Some(SeriesResponseData(List(GetSeries(1L, Some(2L),Some("foo"), Some("code"), Some("bar"))))))
+    val data = GraphqlData(Some(SeriesResponseData(List(GetSeries(1L, Some(2L), Some("foo"), Some("code"), Some("bar"))))))
 
     val dataString: String = data.asJson.printWith(Printer(dropNullValues = false, ""))
 
     wiremockServer.stubFor(post(urlEqualTo("/graphql"))
       .willReturn(okJson(dataString)))
 
-    val result = getSeriesClient.getResult(new BearerAccessToken("token"), getSeriesDocument, Option.empty)
+    val result = getSeriesClient.getResult(new BearerAccessToken("token"), getSeriesDocument, Option.empty, 30.seconds)
     val resultData = await(result)
     assert(resultData.data.isDefined)
     assert(resultData.data.get.getSeries.nonEmpty)
@@ -40,7 +40,7 @@ class GraphQLClientTest extends WireMockTest with Matchers {
   }
 
   "The getResult method " should "return an error from the api" in {
-    val data= GraphqlData(Option.empty, List(Error("error", List(), List(), None)))
+    val data = GraphqlData(Option.empty, List(Error("error", List(), List(), None)))
 
     val dataString: String = data.asJson.printWith(Printer(dropNullValues = false, ""))
 


### PR DESCRIPTION
The default read timeout is 60 seconds, so if the API takes more than 60 seconds, it throws a timeout error.
Created another overloaded method with `readTimout` additional parameter to pass 180 seconds from the draft metadata validator lambda.

